### PR TITLE
url redirection service 구현

### DIFF
--- a/src/main/kotlin/com/tommy/urlshortener/controller/ShortUrlController.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/controller/ShortUrlController.kt
@@ -3,6 +3,7 @@ package com.tommy.urlshortener.controller
 import com.tommy.urlshortener.dto.RedirectResponseEntity
 import com.tommy.urlshortener.dto.ShortUrlRequest
 import com.tommy.urlshortener.dto.ShortUrlResponse
+import com.tommy.urlshortener.service.UrlRedirectService
 import com.tommy.urlshortener.service.UrlShortService
 import com.tommy.urlshortener.service.UrlValidator
 import org.springframework.validation.annotation.Validated
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 class ShortUrlController(
     private val urlValidator: UrlValidator,
     private val urlShortService: UrlShortService,
+    private val urlRedirectService: UrlRedirectService,
 ) {
 
     @PostMapping("/shorten")
@@ -26,6 +28,7 @@ class ShortUrlController(
 
     @GetMapping("/{shortUrl}")
     fun redirect(@PathVariable shortUrl: String): RedirectResponseEntity {
-        return RedirectResponseEntity("EysI9lHD")
+        val originUrlResponse = urlRedirectService.findOriginUrl(shortUrl)
+        return RedirectResponseEntity(originUrlResponse.originUrl)
     }
 }

--- a/src/main/kotlin/com/tommy/urlshortener/dto/OriginUrlResponse.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/dto/OriginUrlResponse.kt
@@ -1,0 +1,5 @@
+package com.tommy.urlshortener.dto
+
+data class OriginUrlResponse(
+    val originUrl: String,
+)

--- a/src/main/kotlin/com/tommy/urlshortener/repository/ShortenUrlRepository.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/repository/ShortenUrlRepository.kt
@@ -10,6 +10,7 @@ interface ShortenUrlRepository : JpaRepository<ShortenUrl, Long>, ShortenUrlRepo
 
 interface ShortenUrlRepositoryCustom {
     fun findByOriginUrl(originUrl: String): ShortenUrl?
+    fun findByShortUrl(shortUrl: String): ShortenUrl?
 }
 
 class ShortenUrlRepositoryImpl(
@@ -21,6 +22,13 @@ class ShortenUrlRepositoryImpl(
         return queryFactory
             .selectFrom(shortenUrl)
             .where(shortenUrl.originUrl.eq(originUrl))
+            .fetchOne()
+    }
+
+    override fun findByShortUrl(shortUrl: String): ShortenUrl? {
+        return queryFactory
+            .selectFrom(shortenUrl)
+            .where(shortenUrl.shortUrl.eq(shortUrl))
             .fetchOne()
     }
 }

--- a/src/main/kotlin/com/tommy/urlshortener/service/UrlRedirectService.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/UrlRedirectService.kt
@@ -1,0 +1,23 @@
+package com.tommy.urlshortener.service
+
+import com.tommy.urlshortener.dto.OriginUrlResponse
+import com.tommy.urlshortener.repository.ShortenUrlRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class UrlRedirectService(
+    private val shortenUrlRepository: ShortenUrlRepository,
+) {
+    private val logger = KotlinLogging.logger { }
+
+    fun findOriginUrl(shortUrl: String): OriginUrlResponse {
+        // TODO: Cache 조회 후 없으면 DB Find
+        logger.debug { "shortUrl: [$shortUrl]" }
+        val shortenUrl = shortenUrlRepository.findByShortUrl(shortUrl) ?: throw RuntimeException() // TODO: NotFoundException
+
+        return OriginUrlResponse(shortenUrl.originUrl)
+    }
+}

--- a/src/test/kotlin/com/tommy/urlshortener/repository/ShortenUrlRepositoryTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/repository/ShortenUrlRepositoryTest.kt
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
+import java.util.UUID
 
 @ActiveProfiles("test")
 @Import(UrlShortenerConfig::class)
@@ -28,6 +29,22 @@ class ShortenUrlRepositoryTest @Autowired constructor(
 
         // Act
         val actual = sut.findByOriginUrl(originUrl)
+
+        // Assert
+        assertThat(actual?.originUrl).isEqualTo(shortenUrl.originUrl)
+    }
+
+    @Test
+    @DisplayName("shortUrl이 주어질 경우 ShortenUrl Entity를 조회한다.")
+    fun `find by short url`() {
+        // Arrange
+        val shortUrl = "EysI9lHD"
+        val shortenUrl = ShortenUrl(shortenKey = 1696691294L, originUrl = UUID.randomUUID().toString(), shortUrl = shortUrl)
+
+        sut.save(shortenUrl)
+
+        // Act
+        val actual = sut.findByShortUrl(shortUrl)
 
         // Assert
         assertThat(actual?.shortUrl).isEqualTo(shortenUrl.shortUrl)

--- a/src/test/kotlin/com/tommy/urlshortener/service/UrlRedirectServiceTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/service/UrlRedirectServiceTest.kt
@@ -1,0 +1,37 @@
+package com.tommy.urlshortener.service
+
+import com.tommy.urlshortener.domain.ShortenUrl
+import com.tommy.urlshortener.repository.ShortenUrlRepository
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class UrlRedirectServiceTest(
+    @MockK private val shortenUrlRepository: ShortenUrlRepository,
+) {
+    @InjectMockKs
+    private lateinit var sut: UrlRedirectService
+
+    @Test
+    @DisplayName("입력받은 short url로 origin url을 찾는다.")
+    fun `find origin url`() {
+        // Arrange
+        val shortUrl = "EysI9lHD"
+        val shortenUrl = ShortenUrl(shortenKey = 1696691294L, originUrl = UUID.randomUUID().toString(), shortUrl = shortUrl)
+
+        every { shortenUrlRepository.findByShortUrl(shortUrl) } returns shortenUrl
+
+        // Act
+        val actual = sut.findOriginUrl(shortUrl)
+
+        // Assert
+        assertThat(actual.originUrl).isEqualTo(shortenUrl.originUrl)
+    }
+}


### PR DESCRIPTION
#### Url Redirection Repository 구현
- ShortUrl을 입력받아 ShortenUrl Entity를 조회한다.

#### Url Redirection 기능 구현
- ShortUrl로 ShortenUrl을 조회하여 OriginUrl을 구한다.
- OriginUrl을 Location Header에 넣어 응답한다.

work items: https://github.com/LimHanGyeol/url-shortener/issues/20