### PR TITLE
shorturl cache 저장

### DIFF
--- a/src/main/kotlin/com/tommy/urlshortener/common/RedisService.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/common/RedisService.kt
@@ -1,43 +1,57 @@
 package com.tommy.urlshortener.common
 
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.core.ValueOperations
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
 import org.springframework.stereotype.Service
 import java.util.concurrent.TimeUnit
 
 @Service
 class RedisService(
-    private val redisTemplate: RedisTemplate<String, Any>,
+    @Value("\${spring.application.name:url-shortener}")
+    private val appName: String,
+    private val objectMapper: ObjectMapper,
+    private val redisTemplate: StringRedisTemplate,
 ) {
-    private val valueOperations: ValueOperations<String, Any> = redisTemplate.opsForValue()
+    private val valueOperations: ValueOperations<String, String> = redisTemplate.opsForValue()
 
-    fun set(key: String, value: Any, duration: Long, timeUnit: TimeUnit) {
-        redisTemplate.valueSerializer = Jackson2JsonRedisSerializer(value::class.java)
-        redisTemplate.opsForValue().set(key, value, duration, timeUnit)
+    fun set(key: String, value: Any, ttl: Long, timeUnit: TimeUnit) {
+        val redisKey = generateKey(key)
+        val serializedValue = objectMapper.writeValueAsString(value)
+        valueOperations.set(redisKey, serializedValue, ttl, timeUnit)
     }
 
-    fun get(key: String): Any? = redisTemplate.opsForValue().get(key)
+    fun <T> get(key: String): T? {
+        val redisKey = generateKey(key)
+        val value = valueOperations.get(redisKey)
+
+        return value?.let {
+            objectMapper.readValue(it, object : TypeReference<T>() {})
+        }
+    }
 
     fun increment(key: String, delta: Long = 1L): Int {
-        val incrementedValue = valueOperations.increment(key, delta)
+        val redisKey = generateKey(key)
+        val incrementedValue = valueOperations.increment(redisKey, delta)
         return incrementedValue?.toInt() ?: 1
     }
 
-    fun increment(key: String, delta: Long = 1L, ttl: Long, timeUnit: TimeUnit): Int {
-        val incrementedValue = valueOperations.increment(key, delta)
-        if (incrementedValue == delta) {
-            redisTemplate.expire(key, ttl, timeUnit)
-        }
-        return incrementedValue?.toInt() ?: 1
-    }
+    fun delete(key: String): Boolean = redisTemplate.delete(generateKey(key))
 
-    fun delete(key: String): Boolean = redisTemplate.delete(key)
-
-    fun hasKey(key: String): Boolean = redisTemplate.hasKey(key)
+    fun hasKey(key: String): Boolean = redisTemplate.hasKey(generateKey(key))
 
     fun deleteAll(key: String) {
-        val keys = redisTemplate.keys(key)
-        redisTemplate.delete(keys)
+        val redisKey = generateKey(key)
+        val keys = redisTemplate.keys("$redisKey:*")
+        if (keys.isNotEmpty()) {
+            redisTemplate.delete(keys)
+        }
+    }
+
+    private fun generateKey(key: String): String {
+        return "$appName:$key"
     }
 }

--- a/src/main/kotlin/com/tommy/urlshortener/controller/ShortUrlController.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/controller/ShortUrlController.kt
@@ -6,11 +6,13 @@ import com.tommy.urlshortener.dto.ShortUrlResponse
 import com.tommy.urlshortener.service.UrlRedirectService
 import com.tommy.urlshortener.service.UrlShortService
 import com.tommy.urlshortener.service.UrlValidator
+import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -21,12 +23,13 @@ class ShortUrlController(
 ) {
 
     @PostMapping("/shorten")
+    @ResponseStatus(HttpStatus.CREATED)
     fun shortUrl(@RequestBody @Validated shortUrlRequest: ShortUrlRequest): ShortUrlResponse {
         urlValidator.validate(shortUrlRequest.originUrl)
         return urlShortService.shorten(shortUrlRequest)
     }
 
-    @GetMapping("/{shortUrl}")
+    @GetMapping("/redirect/{shortUrl}")
     fun redirect(@PathVariable shortUrl: String): RedirectResponseEntity {
         val originUrlResponse = urlRedirectService.findOriginUrl(shortUrl)
         return RedirectResponseEntity(originUrlResponse.originUrl)

--- a/src/test/kotlin/com/tommy/urlshortener/controller/ShortUrlControllerTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/controller/ShortUrlControllerTest.kt
@@ -54,7 +54,7 @@ class ShortUrlControllerTest @Autowired constructor(
                 .content(objectMapper.writeValueAsString(shortUrlRequest))
         )
             .andDo(print())
-            .andExpect(status().isOk)
+            .andExpect(status().isCreated)
             .andExpect(jsonPath("$.shortUrl").value(shortUrlResponse.shortUrl))
 
         verify {
@@ -74,7 +74,7 @@ class ShortUrlControllerTest @Autowired constructor(
 
         // Act & Assert
         mockMvc.perform(
-            get("/{shortUrl}", shortUrl)
+            get("/redirect/{shortUrl}", shortUrl)
                 .contentType(MediaType.APPLICATION_JSON)
         )
             .andDo(print())

--- a/src/test/kotlin/com/tommy/urlshortener/service/UrlShortServiceTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/service/UrlShortServiceTest.kt
@@ -1,5 +1,6 @@
 package com.tommy.urlshortener.service
 
+import com.tommy.urlshortener.common.RedisService
 import com.tommy.urlshortener.domain.ShortenUrl
 import com.tommy.urlshortener.dto.ShortUrlRequest
 import com.tommy.urlshortener.repository.ShortenUrlRepository
@@ -7,13 +8,16 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.justRun
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.util.concurrent.TimeUnit
 
 @ExtendWith(MockKExtension::class)
 class UrlShortServiceTest(
+    @MockK private val redisService: RedisService,
     @MockK private val shortenKeyGenerator: ShortenKeyGenerator,
     @MockK private val shortUrlGenerator: ShortUrlGenerator,
     @MockK private val shortenUrlRepository: ShortenUrlRepository,
@@ -28,19 +32,27 @@ class UrlShortServiceTest(
         val originUrl = "https://github.com/LimHanGyeol/url-shortener/blob/master/src/main/kotlin/com/tommy/urlshortener/UrlShortenerApplication.kt"
         val shortUrlRequest = ShortUrlRequest(originUrl)
 
+        val redisKey = "$REDIS_KEY_PREFIX$originUrl"
+
         val shortenKey = 1696691294L
         val generatedShortUrl = "EysI9lHD"
         val shortenUrl = ShortenUrl(shortenKey = shortenKey, originUrl = originUrl, shortUrl = generatedShortUrl)
 
+        every { redisService.get<String>(redisKey) } returns null
         every { shortenUrlRepository.findByOriginUrl(originUrl) } returns null
         every { shortenKeyGenerator.generate(any()) } returns shortenKey
         every { shortUrlGenerator.generate(shortenKey) } returns generatedShortUrl
         every { shortenUrlRepository.save(any()) } returns shortenUrl
+        justRun { redisService.set(redisKey, shortenUrl.shortUrl, 3L, TimeUnit.DAYS) }
 
         // Act
         val actual = sut.shorten(shortUrlRequest)
 
         // Assert
         assertThat(actual.shortUrl).isEqualTo(generatedShortUrl)
+    }
+
+    companion object {
+        private const val REDIS_KEY_PREFIX = "url:"
     }
 }


### PR DESCRIPTION
#### RedisService 기능 개선
- Redis Key 생성 추가
- objectMapper로 값을 관리하도록 설정
- TypeReference를 외부에서 주입 받도록 변경해야함
- StringRedisTemplate을 이용하여 별도의 Connection, RedisTemplate을 설정하지 않도록 한다.

#### URL 단축 시 Cache 로직 구현
- URL 단축 시 Cache에 해당 OriginUrl이 있는지 찾는다.
- Cache에 없을 경우 DB에서 찾고, DB에 없으면 새로 생성한다.
- 조회/생성한 ShortUrl을 Cache에 저장한다.

work items: https://github.com/LimHanGyeol/url-shortener/issues/24