### PR TITLE
URL Redirection 시 Cache 로직 구현

### DIFF
--- a/src/test/kotlin/com/tommy/urlshortener/service/UrlRedirectServiceTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/service/UrlRedirectServiceTest.kt
@@ -1,19 +1,24 @@
 package com.tommy.urlshortener.service
 
+import com.tommy.urlshortener.common.RedisService
 import com.tommy.urlshortener.domain.ShortenUrl
 import com.tommy.urlshortener.repository.ShortenUrlRepository
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.justRun
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 
 @ExtendWith(MockKExtension::class)
 class UrlRedirectServiceTest(
+    @MockK private val redisService: RedisService,
     @MockK private val shortenUrlRepository: ShortenUrlRepository,
 ) {
     @InjectMockKs
@@ -26,12 +31,26 @@ class UrlRedirectServiceTest(
         val shortUrl = "EysI9lHD"
         val shortenUrl = ShortenUrl(shortenKey = 1696691294L, originUrl = UUID.randomUUID().toString(), shortUrl = shortUrl)
 
+        val redisKey = "$REDIS_KEY_PREFIX$shortUrl"
+
+        every { redisService.get<String>(redisKey) } returns null
         every { shortenUrlRepository.findByShortUrl(shortUrl) } returns shortenUrl
+        justRun { redisService.set(redisKey, shortenUrl.originUrl, 3L, TimeUnit.DAYS) }
 
         // Act
         val actual = sut.findOriginUrl(shortUrl)
 
         // Assert
         assertThat(actual.originUrl).isEqualTo(shortenUrl.originUrl)
+
+        verify {
+            redisService.get<String>(redisKey)
+            shortenUrlRepository.findByShortUrl(shortUrl)
+            redisService.set(redisKey, shortenUrl.originUrl, 3L, TimeUnit.DAYS)
+        }
+    }
+
+    companion object {
+        private const val REDIS_KEY_PREFIX = "redirect:"
     }
 }


### PR DESCRIPTION
- URL Redirection 시 Cache에 해당 ShortUrl이 있는지 찾는다.
- Cache에 없을 경우 DB에서 찾고, DB에 없으면 Exception을 throw한다.
- 조회한 OriginUrl을 Cache에 저장한다.
- Cache Key: url-shortener:redirect:{shortUrl} = OriginUrl

work items: #22