### PR TITLE
exception 공통화 구현

### DIFF
--- a/src/main/kotlin/com/tommy/urlshortener/controller/ShortUrlController.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/controller/ShortUrlController.kt
@@ -7,13 +7,13 @@ import com.tommy.urlshortener.service.UrlRedirectService
 import com.tommy.urlshortener.service.UrlShortService
 import com.tommy.urlshortener.service.UrlValidator
 import org.springframework.http.HttpStatus
-import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import jakarta.validation.Valid
 
 @RestController
 class ShortUrlController(
@@ -24,7 +24,7 @@ class ShortUrlController(
 
     @PostMapping("/shorten")
     @ResponseStatus(HttpStatus.CREATED)
-    fun shortUrl(@RequestBody @Validated shortUrlRequest: ShortUrlRequest): ShortUrlResponse {
+    fun shortUrl(@RequestBody @Valid shortUrlRequest: ShortUrlRequest): ShortUrlResponse {
         urlValidator.validate(shortUrlRequest.originUrl)
         return urlShortService.shorten(shortUrlRequest)
     }

--- a/src/main/kotlin/com/tommy/urlshortener/dto/ErrorResult.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/dto/ErrorResult.kt
@@ -1,0 +1,16 @@
+package com.tommy.urlshortener.dto
+
+class ErrorResult(
+    val code: String,
+    val message: String,
+    val errorFields: List<ErrorField> = emptyList(),
+) {
+    /**
+     * spring.validation의 @Valid, bindingResult로 인해 발생하는 실패 케이스를 매핑한다.
+     */
+    data class ErrorField(
+        val field: String?,
+        val value: Any?,
+        val reason: String?,
+    )
+}

--- a/src/main/kotlin/com/tommy/urlshortener/exception/BadRequestException.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/exception/BadRequestException.kt
@@ -1,0 +1,3 @@
+package com.tommy.urlshortener.exception
+
+class BadRequestException(pair: Pair<String, String>, vararg args: Any?) : BaseException(400, pair.first, pair.second, args)

--- a/src/main/kotlin/com/tommy/urlshortener/exception/BaseException.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/exception/BaseException.kt
@@ -1,0 +1,8 @@
+package com.tommy.urlshortener.exception
+
+open class BaseException(
+    val status: Int,
+    val code: String,
+    val default: String = "",
+    vararg val args: Any?,
+) : RuntimeException(code)

--- a/src/main/kotlin/com/tommy/urlshortener/exception/BaseException.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/exception/BaseException.kt
@@ -5,4 +5,4 @@ open class BaseException(
     val code: String,
     val default: String = "",
     vararg val args: Any?,
-) : RuntimeException(code)
+) : RuntimeException()

--- a/src/main/kotlin/com/tommy/urlshortener/exception/DefaultControllerAdvice.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/exception/DefaultControllerAdvice.kt
@@ -1,0 +1,173 @@
+package com.tommy.urlshortener.exception
+
+import com.tommy.urlshortener.dto.ErrorResult
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.validation.BindException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.UnsatisfiedServletRequestParameterException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.servlet.NoHandlerFoundException
+import java.text.MessageFormat
+import jakarta.validation.ConstraintViolationException
+import jakarta.validation.UnexpectedTypeException
+
+@RestControllerAdvice
+class DefaultControllerAdvice {
+
+    private val logger = KotlinLogging.logger { }
+
+    /**
+     * 비즈니스 익셉션
+     */
+    @ExceptionHandler(BaseException::class)
+    fun handleBaseException(e: BaseException): ResponseEntity<ErrorResult> {
+        val formattedMessage = MessageFormat.format(e.default, *e.args)
+
+        logger.error { formattedMessage }
+
+        val errorResult = ErrorResult(
+            code = e.code,
+            message = formattedMessage,
+        )
+
+        return ResponseEntity(errorResult, HttpStatus.valueOf(e.status))
+    }
+
+    /**
+     * org.springframework.validation 의 validation 실패(@Valid)로 인해 발생하는 예외를 처리.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleMethodArgumentTypeMismatchException(e: MethodArgumentNotValidException): ErrorResult {
+        logger.error(e) { "MethodArgumentNotValidException" }
+
+        val errorFields = e.bindingResult.fieldErrors.map {
+            ErrorResult.ErrorField(field = it.field, value = it.rejectedValue, reason = it.defaultMessage)
+        }
+
+        return ErrorResult(
+            code = "methodArgumentNotValid",
+            message = "다음 항목들은 유효한 값이 아닙니다.",
+            errorFields = errorFields,
+        )
+    }
+
+    /**
+     * Exception Handler
+     * 기본 예외 핸들러, Http Response 500
+     */
+    @ExceptionHandler(Exception::class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun handleException(e: Exception): ErrorResult {
+        logger.error(e) { "throw Exception" }
+
+        return ErrorResult(
+            code = "internalError",
+            message = "Internal server error occurred. Please contact with administrator. (${e.message})",
+        )
+    }
+
+    /**
+     * @description 요청 URL에 해당하는 핸들러(Controller)가 없을 경우 발생하는 예외를 처리.
+     */
+    @ExceptionHandler(NoHandlerFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun handleNoHandlerFoundException(e: NoHandlerFoundException): ErrorResult {
+        logger.error(e) { "NoHandlerFoundException" }
+
+        return ErrorResult(
+            code = "handlerNotFound",
+            message = "Request URL(${e.requestURL}) is not found.",
+        )
+    }
+
+    /**
+     * HttpMessageNotReadableException: HTTP 요청 본문을 Java 객체로 변환할 수 없을 때 발생하는 예외를 처리.(JSON 형식, Type Mismatch)
+     * UnsatisfiedServletRequestParameterException: 요청 매개변수가 특정 조건을 만족하지 않을 때. params에 정의한 조건을 만족하지 않는 경우 발생하는 예외를 처리.
+     * MissingServletRequestParameterException: 필수 요청 매개변수가 누락됐을 때 발생하는 예외를 처리.
+     * UnexpectedTypeException: Bean Validation 시 예상하지 못한 타입의 값이 들어올 때 발생하는 예외를 처리. @Size(min = 5) 일 경우 해당 타입이 boolean으로 전달 될 경우.
+     */
+    @ExceptionHandler(
+        value = [
+            HttpMessageNotReadableException::class,
+            UnsatisfiedServletRequestParameterException::class,
+            MissingServletRequestParameterException::class,
+            UnexpectedTypeException::class,
+        ]
+    )
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleBadRequestException(e: Exception): ErrorResult {
+        val exceptionName = e::class.simpleName
+        logger.error(e) { exceptionName }
+
+        return ErrorResult(
+            code = "badRequest.$exceptionName",
+            message = "Bad request: ${e.localizedMessage}",
+        )
+    }
+
+    /**
+     * MethodArgumentTypeMismatchException: Controller의 매개변수 타입과 요청에서 전달된 값의 타입이 일치하지 않을 때 발생하는 예외를 처리.
+     * 매개변수 타입이 Integer 일 경우 요청으로 다른 형식의 값이 전달 될 경우.
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleMethodArgumentTypeMismatchException(e: MethodArgumentTypeMismatchException): ErrorResult {
+        logger.error(e) { "MethodArgumentTypeMismatchException" }
+
+        return ErrorResult(
+            code = "invalidType.${e.requiredType?.simpleName ?: "null"}",
+            message = "`${e.name}`'s type should be `${e.requiredType?.simpleName}`.",
+        )
+    }
+
+    /**
+     * ConstraintViolationException: Bean Validation에서 @Validated를 사용하여 @PathVariable, @RequestParam, @RequestHeader 등 값에 대해 유효성 검사가 실패 할 때 발생하는 예외를 처리.
+     */
+    @ExceptionHandler(ConstraintViolationException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleConstraintViolationException(e: ConstraintViolationException): ErrorResult {
+        logger.error(e) { "ConstraintViolationException" }
+
+        val errorFields = e.constraintViolations.map { violation ->
+            val constraint = violation.constraintDescriptor.constraintValidatorClasses.firstOrNull()
+            val node = violation.propertyPath.lastOrNull()
+
+            val reason = MessageFormat.format("Constraint failed: {0}", node?.name)
+
+            ErrorResult.ErrorField(
+                field = "constraintViolation.${constraint?.simpleName ?: "null"}", value = violation.invalidValue, reason = reason,
+            )
+        }
+
+        return ErrorResult(code = "constraintViolation", message = "다음 항목들은 유효한 값이 아닙니다.", errorFields = errorFields)
+    }
+
+    /**
+     * BindException Handler: 일반적인 데이터 바인딩 실패 시 발생하는 예외를 처리.
+     */
+    @ExceptionHandler(BindException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleBindException(e: BindException): ErrorResult {
+        logger.error(e) { "BindException" }
+
+        val errorFields = e.bindingResult.fieldErrors.map {
+            ErrorResult.ErrorField(
+                field = it.field, value = it.rejectedValue, reason = it.defaultMessage
+            )
+        }
+
+        return ErrorResult(
+            code = "bindException",
+            message = "다음 항목들은 유효한 값이 아닙니다.",
+            errorFields = errorFields,
+        )
+    }
+}

--- a/src/main/kotlin/com/tommy/urlshortener/exception/DefaultControllerAdvice.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/exception/DefaultControllerAdvice.kt
@@ -40,7 +40,7 @@ class DefaultControllerAdvice {
 
         val formattedMessage = MessageFormat.format(e.default, *arguments)
 
-        logger.error { formattedMessage }
+        logger.error(e) { formattedMessage }
 
         val errorResult = ErrorResult(
             code = e.code,

--- a/src/main/kotlin/com/tommy/urlshortener/exception/DefaultControllerAdvice.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/exception/DefaultControllerAdvice.kt
@@ -28,7 +28,17 @@ class DefaultControllerAdvice {
      */
     @ExceptionHandler(BaseException::class)
     fun handleBaseException(e: BaseException): ResponseEntity<ErrorResult> {
-        val formattedMessage = MessageFormat.format(e.default, *e.args)
+        // vararg는 Java에서 배열로 처리된다. 그래서 args는 Array<Any?>로 전다로딘다.
+        // args 자체가 배열로 컴파일된다. 내부 원소 또한 배열일 수 있어서 포맷팅을 위해선 두 단계의 배열을 풀어줘야한다.
+        // TODO: 가변인자를 추가 배열로 넘길 경우 확인하기
+        val arguments = e.args.flatMap {
+            when (it) {
+                is Array<*> -> it.toList()
+                else -> listOf(it)
+            }
+        }.toTypedArray()
+
+        val formattedMessage = MessageFormat.format(e.default, *arguments)
 
         logger.error { formattedMessage }
 

--- a/src/main/kotlin/com/tommy/urlshortener/exception/InternalServerException.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/exception/InternalServerException.kt
@@ -1,0 +1,5 @@
+package com.tommy.urlshortener.exception
+
+import org.springframework.http.HttpStatus
+
+class InternalServerException(pair: Pair<String, String>, vararg args: Any?) : BaseException(HttpStatus.INTERNAL_SERVER_ERROR.value(), pair.first, pair.second)

--- a/src/main/kotlin/com/tommy/urlshortener/exception/NotFoundException.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/exception/NotFoundException.kt
@@ -1,0 +1,5 @@
+package com.tommy.urlshortener.exception
+
+import org.springframework.http.HttpStatus
+
+class NotFoundException(pair: Pair<String, String>, vararg args: Any?) : BaseException(HttpStatus.NOT_FOUND.value(), pair.first, pair.second)

--- a/src/main/kotlin/com/tommy/urlshortener/exception/TooManyRequestException.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/exception/TooManyRequestException.kt
@@ -1,0 +1,3 @@
+package com.tommy.urlshortener.exception
+
+class TooManyRequestException(pair: Pair<String, String>, vararg args: Any?) : BaseException(429, pair.first, pair.second, args)

--- a/src/main/kotlin/com/tommy/urlshortener/service/ShortUrlGenerator.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/ShortUrlGenerator.kt
@@ -1,9 +1,13 @@
 package com.tommy.urlshortener.service
 
+import com.tommy.urlshortener.exception.InternalServerException
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
 
 @Component
 class ShortUrlGenerator {
+
+    private val logger = KotlinLogging.logger { }
 
     fun generate(shortenKey: Long): String {
         if (shortenKey == 0L) {
@@ -22,7 +26,8 @@ class ShortUrlGenerator {
         val generatedUrl = stringBuilder.reverse().toString()
 
         if (generatedUrl.length > URL_LENGTH_LIMIT) {
-            throw RuntimeException("단축된 URL이 8자 이상입니다. 관리자에게 문의해주세요.")
+            logger.error { "generated url limit length exceed: ${generatedUrl.length}" }
+            throw InternalServerException(URL_LENGTH_LIMIT_EXCEED, generatedUrl, generatedUrl.length)
         }
 
         return generatedUrl
@@ -32,5 +37,7 @@ class ShortUrlGenerator {
         private const val BASE62 = 62
         private const val URL_LENGTH_LIMIT = 8
         private val BASE62_CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray()
+
+        private val URL_LENGTH_LIMIT_EXCEED = "shortUrl.length.limit.exceed" to "current short url: {0}, length: {1}"
     }
 }

--- a/src/main/kotlin/com/tommy/urlshortener/service/ShortenKeyGenerator.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/ShortenKeyGenerator.kt
@@ -1,6 +1,7 @@
 package com.tommy.urlshortener.service
 
 import com.tommy.urlshortener.common.RedisService
+import com.tommy.urlshortener.exception.TooManyRequestException
 import org.springframework.stereotype.Component
 import java.util.concurrent.TimeUnit
 
@@ -18,7 +19,7 @@ class ShortenKeyGenerator(
         val incrementedValue = redisService.increment(REDIS_KEY, 1L)
 
         if (incrementedValue > MAX_SEQUENTIAL) {
-            throw RuntimeException() // TODO: 초당 최대 생성수 초과 잠시후 재시도 권유
+            throw TooManyRequestException(MAX_SEQUENTIAL_NUMBER_EXCEED, incrementedValue)
         }
         redisService.set(REDIS_KEY, incrementedValue, 5, TimeUnit.SECONDS)
 
@@ -28,5 +29,7 @@ class ShortenKeyGenerator(
     companion object {
         private const val REDIS_KEY = "shortener:sequential"
         private const val MAX_SEQUENTIAL = 9999
+
+        private val MAX_SEQUENTIAL_NUMBER_EXCEED = "maxSequential.exceed" to "current sequential number: {0}"
     }
 }

--- a/src/main/kotlin/com/tommy/urlshortener/service/UrlRedirectService.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/UrlRedirectService.kt
@@ -2,6 +2,7 @@ package com.tommy.urlshortener.service
 
 import com.tommy.urlshortener.common.RedisService
 import com.tommy.urlshortener.dto.OriginUrlResponse
+import com.tommy.urlshortener.exception.NotFoundException
 import com.tommy.urlshortener.repository.ShortenUrlRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
@@ -25,7 +26,7 @@ class UrlRedirectService(
         return cachedOriginUrl?.let {
             OriginUrlResponse(it)
         } ?: run {
-            val shortenUrl = shortenUrlRepository.findByShortUrl(shortUrl) ?: throw RuntimeException() // TODO: NotFoundException
+            val shortenUrl = shortenUrlRepository.findByShortUrl(shortUrl) ?: throw NotFoundException(SHORTEN_URL_NOT_FOUND, shortUrl)
             val originUrl = shortenUrl.originUrl
 
             redisService.set(redisKey, originUrl, 3L, TimeUnit.DAYS)
@@ -36,5 +37,7 @@ class UrlRedirectService(
 
     companion object {
         private const val REDIS_KEY_PREFIX = "redirect:"
+
+        private val SHORTEN_URL_NOT_FOUND = "shortenUrl.notFound" to "shortenUrl not found. shortUrl: {0}"
     }
 }

--- a/src/main/kotlin/com/tommy/urlshortener/service/UrlValidator.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/UrlValidator.kt
@@ -1,14 +1,20 @@
 package com.tommy.urlshortener.service
 
+import com.tommy.urlshortener.exception.BadRequestException
 import org.apache.commons.validator.routines.UrlValidator
 import org.springframework.stereotype.Component
 
 @Component
 class UrlValidator {
 
-    fun validate(originUrl: String) {
+    fun validate(originUrl: String): Boolean {
         if (!UrlValidator().isValid(originUrl)) {
-            throw RuntimeException() // TODO: 올바르지 않은 URL 형식 Exception 발생
+            throw BadRequestException(INVALID_ORIGIN_URL, originUrl)
         }
+        return true
+    }
+
+    companion object {
+        private val INVALID_ORIGIN_URL = "originUrl.invalid" to "invalid origin url: {0}"
     }
 }

--- a/src/test/kotlin/com/tommy/urlshortener/service/ShortUrlGeneratorTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/service/ShortUrlGeneratorTest.kt
@@ -1,17 +1,20 @@
 package com.tommy.urlshortener.service
 
+import com.tommy.urlshortener.exception.InternalServerException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 
 class ShortUrlGeneratorTest {
+
+    private val sut = ShortUrlGenerator()
 
     @Test
     @DisplayName("BASE62를 이용하여 ShortUrl을 생성한다.")
     fun `generate short url`() { // Arrange
         val shortenKey = 16963217089999L
-        val sut = ShortUrlGenerator()
 
         // Act
         val actual = sut.generate(shortenKey)
@@ -20,5 +23,15 @@ class ShortUrlGeneratorTest {
         assertThat(actual).isEqualTo("EyoG2LrJ")
         assertThat(actual).hasSizeLessThanOrEqualTo(8)
         assertThat(actual).containsPattern("^[a-zA-Z0-9]+$")
+    }
+
+    @Test
+    @DisplayName("생성된 ShortUrl의 길이가 8자를 초과할 경우 InternalServerException이 발생한다.")
+    fun `generated failed short url`() {
+        // Arrange
+        val shortenKey = 435457421885459952L // snowflake id. 2023-10-03 17:04:03.500
+
+        // Act & Assert
+        assertThrows<InternalServerException> { sut.generate(shortenKey) }
     }
 }

--- a/src/test/kotlin/com/tommy/urlshortener/service/ShortenKeyGeneratorTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/service/ShortenKeyGeneratorTest.kt
@@ -1,6 +1,7 @@
 package com.tommy.urlshortener.service
 
 import com.tommy.urlshortener.common.RedisService
+import com.tommy.urlshortener.exception.TooManyRequestException
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
@@ -43,11 +44,11 @@ class ShortenKeyGeneratorTest(
         // Arrange
         val timestamp = Instant.now().epochSecond
 
-        every { redisService.increment(REDIS_KEY, 1L) } returns 10000
+         every { redisService.increment(REDIS_KEY, 1L) } returns 10000
         justRun { redisService.set(REDIS_KEY, 10000, 5, TimeUnit.SECONDS) }
 
         // Act & Assert
-        assertThrows<RuntimeException> { sut.generate(timestamp) }
+        assertThrows<TooManyRequestException> { sut.generate(timestamp) }
     }
 
     companion object {

--- a/src/test/kotlin/com/tommy/urlshortener/service/UrlValidatorTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/service/UrlValidatorTest.kt
@@ -1,0 +1,37 @@
+package com.tommy.urlshortener.service
+
+import com.tommy.urlshortener.exception.BadRequestException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class UrlValidatorTest {
+
+    private val sut = UrlValidator()
+
+    @Test
+    @DisplayName("올바른 URL일 경우 검증을 통과한다.")
+    fun validate() {
+        // Arrange
+        val originUrl = "https://github.com/LimHanGyeol/url-shortener/blob/master/src/main/kotlin/com/tommy/urlshortener/UrlShortenerApplication.kt"
+
+        // Act
+        val actual = sut.validate(originUrl)
+
+        // Assert
+        assertThat(actual).isTrue
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 URL 형식일 경우 BadRequestException이 발생한다.")
+    fun `validate failed`() {
+        // Arrange
+        val originUrl = "url-shortener, limhangyeol"
+
+        // Act & Assert
+        val actual = assertThrows<BadRequestException> { sut.validate(originUrl) }
+        assertThat(actual.status).isEqualTo(400)
+        assertThat(actual.code).isEqualTo("originUrl.invalid")
+    }
+}


### PR DESCRIPTION
#### 65ada60 Exception 공통화 구현
- Exception 발생 시 응답 스펙을 공통화 한다.
- BaseException 구현
- ErrorResult 구현
- DefaultControllerAdvice 구현

#### acc2148 BadRequestException 추가
#### 881948d UrlValidator Exception Case 개선
- URL 유효성 검증에 실패할 경우 BadRequestException을 발생시킨다.
- UrlValidatorTest 추가
- ShortUrlController.Url 단축 시 실패 케이스 테스트코드 추가

#### 5035467 TooManyRequestException 추가
#### 55dae6b ShortenKeyGenerator Exception Case 개선
- ShortenKeyGenerate 시 MAX_SEQUENTIAL 9999가 초과되면 TooManyRequestException을 발생시킨다.

#### ffe5e2d InternalServerException 추가
#### 4e5d7a3 ShortUrlGenerator Exception Case 개선
- URL_LENGTH_LIMIT 초과 시 InternalServerException을 발생시킨다.
- 실패 케이스 테스트코드 추가

#### ddfdba5 NotFoundException 추가
#### 6b99a7d UrlRedirectService Exception Case 개선
- shortenUrlRepository.findByShortUrl(shortUrl)의 결과가 null일 경우 NotFoundException을 발생시킨다.(존재하지 않는 ShortenUrl)
- 실패 케이스 테스트코드 추가

work items: https://github.com/LimHanGyeol/url-shortener/issues/23




