### PR TITLE
ShortenKeyGenerator 로직 개선

### DIFF
--- a/src/main/kotlin/com/tommy/urlshortener/dto/RedirectResponseEntity.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/dto/RedirectResponseEntity.kt
@@ -16,4 +16,3 @@ class RedirectResponseEntity(location: String)
         }
     }
 }
-

--- a/src/main/kotlin/com/tommy/urlshortener/service/ShortenKeyGenerator.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/ShortenKeyGenerator.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit
 class ShortenKeyGenerator(
     private val redisService: RedisService,
 ) {
-    fun generate(timestamp: Long): Long { // TODO: 동시성 문제 검토 필요
+    fun generate(timestamp: Long): Long {
         val sequentialNumber = incrementSequentialNumber()
 
         return "$timestamp${String.format("%04d", sequentialNumber)}".toLong()
@@ -20,8 +20,9 @@ class ShortenKeyGenerator(
 
         if (incrementedValue > MAX_SEQUENTIAL) {
             throw TooManyRequestException(MAX_SEQUENTIAL_NUMBER_EXCEED, incrementedValue)
+        } else {
+            redisService.set(REDIS_KEY, incrementedValue, 5, TimeUnit.SECONDS)
         }
-        redisService.set(REDIS_KEY, incrementedValue, 5, TimeUnit.SECONDS)
 
         return incrementedValue
     }

--- a/src/main/kotlin/com/tommy/urlshortener/service/UrlRedirectService.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/UrlRedirectService.kt
@@ -17,6 +17,7 @@ class UrlRedirectService(
 ) {
     private val logger = KotlinLogging.logger { }
 
+    @Transactional
     fun findOriginUrl(shortUrl: String): OriginUrlResponse {
         logger.debug { "shortUrl: [$shortUrl]" }
 


### PR DESCRIPTION
- 최대 시퀀셜 번호 9999가 초과 될 때, 해당 시기에 동시에 요청이 들어올 경우 동시성 문제가 발생할 수 있다. 해당 로직을 개선한다.

work items: #29