### PR TITLE
url 단축 후 cache 저장 시 originurl hashing

### DIFF
--- a/src/main/kotlin/com/tommy/urlshortener/common/StringUtil.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/common/StringUtil.kt
@@ -1,0 +1,13 @@
+package com.tommy.urlshortener.common
+
+import java.security.MessageDigest
+
+object StringUtil {
+
+    private const val SHA_256 = "SHA-256"
+
+    fun hashToHex(input: String, hashAlgorithm: String = SHA_256): String {
+        val bytes = MessageDigest.getInstance(hashAlgorithm).digest(input.toByteArray())
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/src/main/kotlin/com/tommy/urlshortener/domain/ShortenUrl.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/domain/ShortenUrl.kt
@@ -19,7 +19,7 @@ class ShortenUrl(
     val originUrl: String,
 
     @Column(unique = true)
-    val hashedOriginUrl: String,
+    val hashedOriginUrl: String, // TODO: Index 지정
 
     val shortUrl: String,
 ) : BaseEntity() {

--- a/src/main/kotlin/com/tommy/urlshortener/domain/ShortenUrl.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/domain/ShortenUrl.kt
@@ -15,8 +15,11 @@ class ShortenUrl(
     val shortenKey: Long,
 
     @Lob
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", unique = true)
     val originUrl: String,
+
+    @Column(unique = true)
+    val hashedOriginUrl: String,
 
     val shortUrl: String,
 ) : BaseEntity() {
@@ -39,6 +42,6 @@ class ShortenUrl(
     }
 
     override fun toString(): String {
-        return "ShortenUrl(shortenKey=$shortenKey, originUrl='$originUrl', shortUrl='$shortUrl', id=$id)"
+        return "ShortenUrl(shortenKey=$shortenKey, originUrl='$originUrl', hashedOriginUrl='$hashedOriginUrl', shortUrl='$shortUrl', id=$id)"
     }
 }

--- a/src/main/kotlin/com/tommy/urlshortener/service/UrlShortService.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/UrlShortService.kt
@@ -1,6 +1,7 @@
 package com.tommy.urlshortener.service
 
 import com.tommy.urlshortener.common.RedisService
+import com.tommy.urlshortener.common.StringUtil
 import com.tommy.urlshortener.domain.ShortenUrl
 import com.tommy.urlshortener.dto.ShortUrlRequest
 import com.tommy.urlshortener.dto.ShortUrlResponse
@@ -44,11 +45,13 @@ class UrlShortService(
     private fun saveShortenUrl(originUrl: String): ShortenUrl {
         val timestamp = Instant.now().epochSecond
 
+        val hashedOriginUrl = StringUtil.hashToHex(originUrl)
+
         val shortenKey = shortenKeyGenerator.generate(timestamp)
         val generatedShortUrl = shortUrlGenerator.generate(shortenKey)
 
         return shortenUrlRepository.save(
-            ShortenUrl(shortenKey = shortenKey, originUrl = originUrl, shortUrl = generatedShortUrl)
+            ShortenUrl(shortenKey = shortenKey, originUrl = originUrl, hashedOriginUrl = hashedOriginUrl, shortUrl = generatedShortUrl)
         )
     }
 

--- a/src/main/kotlin/com/tommy/urlshortener/service/UrlShortService.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/UrlShortService.kt
@@ -27,13 +27,14 @@ class UrlShortService(
         val originUrl = shortUrlRequest.originUrl
         logger.debug { "URL Shorten - originUrl: [$originUrl]" }
 
-        val redisKey = "$REDIS_KEY_PREFIX$originUrl"
+        val hashedOriginUrl = StringUtil.hashToHex(originUrl)
+        val redisKey = "$REDIS_KEY_PREFIX$hashedOriginUrl"
         val cachedShortUrl = redisService.get<String>(redisKey)
 
         return cachedShortUrl?.let {
             ShortUrlResponse(it)
         } ?: run {
-            val shortenUrl = shortenUrlRepository.findByOriginUrl(originUrl) ?: saveShortenUrl(originUrl)
+            val shortenUrl = shortenUrlRepository.findByOriginUrl(hashedOriginUrl) ?: saveShortenUrl(originUrl)
             val shortUrl = shortenUrl.shortUrl
 
             redisService.set(redisKey, shortUrl, 3L, TimeUnit.DAYS)

--- a/src/test/kotlin/com/tommy/urlshortener/common/StringUtilTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/common/StringUtilTest.kt
@@ -1,0 +1,21 @@
+package com.tommy.urlshortener.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class StringUtilTest {
+
+    @Test
+    @DisplayName("특정 문자열을 SHA-256 알고리즘으로 해시한다.")
+    fun hashToHex() {
+        // Arrange
+        val input = "https://github.com/LimHanGyeol/url-shortener/blob/master/src/main/kotlin/com/tommy/urlshortener/UrlShortenerApplication.kt"
+
+        // Act
+        val actual = StringUtil.hashToHex(input)
+
+        // Assert
+        assertThat(actual).isEqualTo("bf7ff9439eedb0e61b0c0cd8393f48fe359b39369debc6066e05a0cb470c4f8f")
+    }
+}

--- a/src/test/kotlin/com/tommy/urlshortener/repository/ShortenUrlRepositoryTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/repository/ShortenUrlRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.tommy.urlshortener.repository
 
+import com.tommy.urlshortener.common.StringUtil
 import com.tommy.urlshortener.config.UrlShortenerConfig
 import com.tommy.urlshortener.domain.ShortenUrl
 import org.assertj.core.api.Assertions.assertThat
@@ -23,7 +24,7 @@ class ShortenUrlRepositoryTest @Autowired constructor(
     fun `find by origin url`() {
         // Arrange
         val originUrl = "https://github.com/LimHanGyeol/url-shortener/blob/master/src/main/kotlin/com/tommy/urlshortener/UrlShortenerApplication.kt"
-        val shortenUrl = ShortenUrl(shortenKey = 1696691294L, originUrl = originUrl, shortUrl = "EysI9lHD")
+        val shortenUrl = ShortenUrl(shortenKey = 1696691294L, originUrl = originUrl, hashedOriginUrl = StringUtil.hashToHex(originUrl), shortUrl = "EysI9lHD")
 
         sut.save(shortenUrl)
 
@@ -38,8 +39,9 @@ class ShortenUrlRepositoryTest @Autowired constructor(
     @DisplayName("shortUrl이 주어질 경우 ShortenUrl Entity를 조회한다.")
     fun `find by short url`() {
         // Arrange
+        val originUrl = UUID.randomUUID().toString()
         val shortUrl = "EysI9lHD"
-        val shortenUrl = ShortenUrl(shortenKey = 1696691294L, originUrl = UUID.randomUUID().toString(), shortUrl = shortUrl)
+        val shortenUrl = ShortenUrl(shortenKey = 1696691294L, originUrl = originUrl, hashedOriginUrl = StringUtil.hashToHex(originUrl), shortUrl = shortUrl)
 
         sut.save(shortenUrl)
 

--- a/src/test/kotlin/com/tommy/urlshortener/service/UrlRedirectServiceTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/service/UrlRedirectServiceTest.kt
@@ -1,6 +1,7 @@
 package com.tommy.urlshortener.service
 
 import com.tommy.urlshortener.common.RedisService
+import com.tommy.urlshortener.common.StringUtil
 import com.tommy.urlshortener.domain.ShortenUrl
 import com.tommy.urlshortener.exception.NotFoundException
 import com.tommy.urlshortener.repository.ShortenUrlRepository
@@ -30,8 +31,9 @@ class UrlRedirectServiceTest(
     @DisplayName("입력받은 short url로 origin url을 찾는다.")
     fun `find origin url`() {
         // Arrange
+        val originUrl = UUID.randomUUID().toString()
         val shortUrl = "EysI9lHD"
-        val shortenUrl = ShortenUrl(shortenKey = 1696691294L, originUrl = UUID.randomUUID().toString(), shortUrl = shortUrl)
+        val shortenUrl = ShortenUrl(shortenKey = 1696691294L, originUrl = originUrl, hashedOriginUrl = StringUtil.hashToHex(originUrl), shortUrl = shortUrl)
 
         val redisKey = "$REDIS_KEY_PREFIX$shortUrl"
 

--- a/src/test/kotlin/com/tommy/urlshortener/service/UrlShortServiceTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/service/UrlShortServiceTest.kt
@@ -33,14 +33,15 @@ class UrlShortServiceTest(
         val originUrl = "https://github.com/LimHanGyeol/url-shortener/blob/master/src/main/kotlin/com/tommy/urlshortener/UrlShortenerApplication.kt"
         val shortUrlRequest = ShortUrlRequest(originUrl)
 
-        val redisKey = "$REDIS_KEY_PREFIX$originUrl"
+        val hashedOriginUrl = StringUtil.hashToHex(originUrl)
+        val redisKey = "$REDIS_KEY_PREFIX$hashedOriginUrl"
 
         val shortenKey = 1696691294L
         val generatedShortUrl = "EysI9lHD"
-        val shortenUrl = ShortenUrl(shortenKey = shortenKey, originUrl = originUrl, hashedOriginUrl = StringUtil.hashToHex(originUrl), shortUrl = generatedShortUrl)
+        val shortenUrl = ShortenUrl(shortenKey = shortenKey, originUrl = originUrl, hashedOriginUrl = hashedOriginUrl, shortUrl = generatedShortUrl)
 
         every { redisService.get<String>(redisKey) } returns null
-        every { shortenUrlRepository.findByOriginUrl(originUrl) } returns null
+        every { shortenUrlRepository.findByOriginUrl(hashedOriginUrl) } returns null
         every { shortenKeyGenerator.generate(any()) } returns shortenKey
         every { shortUrlGenerator.generate(shortenKey) } returns generatedShortUrl
         every { shortenUrlRepository.save(any()) } returns shortenUrl

--- a/src/test/kotlin/com/tommy/urlshortener/service/UrlShortServiceTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/service/UrlShortServiceTest.kt
@@ -1,6 +1,7 @@
 package com.tommy.urlshortener.service
 
 import com.tommy.urlshortener.common.RedisService
+import com.tommy.urlshortener.common.StringUtil
 import com.tommy.urlshortener.domain.ShortenUrl
 import com.tommy.urlshortener.dto.ShortUrlRequest
 import com.tommy.urlshortener.repository.ShortenUrlRepository
@@ -36,7 +37,7 @@ class UrlShortServiceTest(
 
         val shortenKey = 1696691294L
         val generatedShortUrl = "EysI9lHD"
-        val shortenUrl = ShortenUrl(shortenKey = shortenKey, originUrl = originUrl, shortUrl = generatedShortUrl)
+        val shortenUrl = ShortenUrl(shortenKey = shortenKey, originUrl = originUrl, hashedOriginUrl = StringUtil.hashToHex(originUrl), shortUrl = generatedShortUrl)
 
         every { redisService.get<String>(redisKey) } returns null
         every { shortenUrlRepository.findByOriginUrl(originUrl) } returns null


### PR DESCRIPTION
#### ShortenUrl Domain에 hashedOriginUrl 속성 추가
- OriginUrl을 Hash한 값을 의미하는 hashedOriginUrl을 추가한다.

#### SHA-256 해시 기능 구현
- SHA-256 알고리즘으로 해시하는 기능을 구현한다.

#### URL 단축 시 OriginUrl Hash
- URL 단축 시 OriginUrl을 SHA-256 방식으로 Hash한다.
- 짧아진 HexString을 RedisKey로 관리한다.
- HashedOriginUrl 속성에 인덱스 설정 예정

work items: https://github.com/LimHanGyeol/url-shortener/issues/32