### PR TITLE
redis cache service 개선

### DIFF
--- a/src/main/kotlin/com/tommy/urlshortener/extension/StringUtil.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/extension/StringUtil.kt
@@ -1,4 +1,4 @@
-package com.tommy.urlshortener.common
+package com.tommy.urlshortener.extension
 
 import java.security.MessageDigest
 

--- a/src/main/kotlin/com/tommy/urlshortener/service/ShortenKeyGenerator.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/ShortenKeyGenerator.kt
@@ -1,13 +1,13 @@
 package com.tommy.urlshortener.service
 
-import com.tommy.urlshortener.common.RedisService
+import com.tommy.urlshortener.cache.ManagedCache
 import com.tommy.urlshortener.exception.TooManyRequestException
 import org.springframework.stereotype.Component
 import java.util.concurrent.TimeUnit
 
 @Component
 class ShortenKeyGenerator(
-    private val redisService: RedisService,
+    private val managedCache: ManagedCache,
 ) {
     fun generate(timestamp: Long): Long {
         val sequentialNumber = incrementSequentialNumber()
@@ -16,12 +16,12 @@ class ShortenKeyGenerator(
     }
 
     private fun incrementSequentialNumber(): Int {
-        val incrementedValue = redisService.increment(REDIS_KEY, 1L)
+        val incrementedValue = managedCache.increment(REDIS_KEY, 1L)
 
         if (incrementedValue > MAX_SEQUENTIAL) {
             throw TooManyRequestException(MAX_SEQUENTIAL_NUMBER_EXCEED, incrementedValue)
         } else {
-            redisService.set(REDIS_KEY, incrementedValue, 5, TimeUnit.SECONDS)
+            managedCache.set(REDIS_KEY, incrementedValue, 5, TimeUnit.SECONDS)
         }
 
         return incrementedValue

--- a/src/test/kotlin/com/tommy/urlshortener/cache/StringUtilTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/cache/StringUtilTest.kt
@@ -1,5 +1,6 @@
-package com.tommy.urlshortener.common
+package com.tommy.urlshortener.cache
 
+import com.tommy.urlshortener.extension.StringUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/tommy/urlshortener/repository/ShortenUrlRepositoryTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/repository/ShortenUrlRepositoryTest.kt
@@ -1,6 +1,6 @@
 package com.tommy.urlshortener.repository
 
-import com.tommy.urlshortener.common.StringUtil
+import com.tommy.urlshortener.extension.StringUtil
 import com.tommy.urlshortener.config.UrlShortenerConfig
 import com.tommy.urlshortener.domain.ShortenUrl
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/com/tommy/urlshortener/service/ShortenKeyGeneratorTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/service/ShortenKeyGeneratorTest.kt
@@ -1,6 +1,6 @@
 package com.tommy.urlshortener.service
 
-import com.tommy.urlshortener.common.RedisService
+import com.tommy.urlshortener.cache.ManagedCache
 import com.tommy.urlshortener.exception.TooManyRequestException
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit
 
 @ExtendWith(MockKExtension::class)
 class ShortenKeyGeneratorTest(
-    @MockK private val redisService: RedisService,
+    @MockK private val managedCache: ManagedCache,
 ) {
     @InjectMockKs
     private lateinit var sut: ShortenKeyGenerator
@@ -28,8 +28,8 @@ class ShortenKeyGeneratorTest(
         // Arrange
         val timestamp = Instant.now().epochSecond
 
-        every { redisService.increment(REDIS_KEY, 1L) } returns 300
-        justRun { redisService.set(REDIS_KEY, 300, 5, TimeUnit.SECONDS) }
+        every { managedCache.increment(REDIS_KEY, 1L) } returns 300
+        justRun { managedCache.set(REDIS_KEY, 300, 5, TimeUnit.SECONDS) }
 
         // Act
         val actual = sut.generate(timestamp)
@@ -44,8 +44,8 @@ class ShortenKeyGeneratorTest(
         // Arrange
         val timestamp = Instant.now().epochSecond
 
-         every { redisService.increment(REDIS_KEY, 1L) } returns 10000
-        justRun { redisService.set(REDIS_KEY, 10000, 5, TimeUnit.SECONDS) }
+         every { managedCache.increment(REDIS_KEY, 1L) } returns 10000
+        justRun { managedCache.set(REDIS_KEY, 10000, 5, TimeUnit.SECONDS) }
 
         // Act & Assert
         assertThrows<TooManyRequestException> { sut.generate(timestamp) }


### PR DESCRIPTION
#### common package 정리
- common package를 분리한다.
- StringUtil을 extension package로 이동한다.
- 별도의 PR에서 StringUtil 개선 예정

#### redis cache service 개선
- common package 네이밍 변경 -> cache
- RedisService -> ManagedCache 클래스 네이밍 변경
- managedCache.get 로직 개선
  - 기존 TypeReference 사용성을 개선한다.
  - CacheValue Wrapper Class 추가
  - Jackson Kotlin Module을 사용하여 확장 함수를 사용한다.
  - 확장 함수에 내제된 TypeReference를 주입하여 TypeReference 사용성을 개선한다.

work items: https://github.com/LimHanGyeol/url-shortener/issues/27