### PR TITLE
Url 단축 시 동시성 제어

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("io.github.oshai:kotlin-logging-jvm:5.1.0")
     implementation("commons-validator:commons-validator:1.7")
+    implementation("org.redisson:redisson-spring-boot-starter:3.24.3")
 
     implementation("com.h2database:h2:2.2.224")
 

--- a/src/main/kotlin/com/tommy/urlshortener/config/RedisConfig.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/config/RedisConfig.kt
@@ -1,0 +1,29 @@
+package com.tommy.urlshortener.config
+
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RedisConfig(
+    @Value("\${spring.data.redis.host}")
+    private val host: String,
+    @Value("\${spring.data.redis.port}")
+    private val port: Int,
+) {
+
+    @Bean
+    fun redissonClient(): RedissonClient { // 운영 환경에서의 Service Mode(Single, Cluster) 개선 필요
+        val config = Config().apply {
+            this.useSingleServer().address = "$REDISSON_HOST_PREFIX$host:$port"
+        }
+        return Redisson.create(config)
+    }
+
+    companion object {
+        private const val REDISSON_HOST_PREFIX = "redis://" // SSL 통신 시 rediss:// 지정
+    }
+}

--- a/src/main/kotlin/com/tommy/urlshortener/controller/ShortUrlController.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/controller/ShortUrlController.kt
@@ -4,7 +4,7 @@ import com.tommy.urlshortener.dto.RedirectResponseEntity
 import com.tommy.urlshortener.dto.ShortUrlRequest
 import com.tommy.urlshortener.dto.ShortUrlResponse
 import com.tommy.urlshortener.service.UrlRedirectService
-import com.tommy.urlshortener.service.UrlShortService
+import com.tommy.urlshortener.service.UrlShortenFacade
 import com.tommy.urlshortener.service.UrlValidator
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
@@ -18,7 +18,7 @@ import jakarta.validation.Valid
 @RestController
 class ShortUrlController(
     private val urlValidator: UrlValidator,
-    private val urlShortService: UrlShortService,
+    private val urlShortenFacade: UrlShortenFacade,
     private val urlRedirectService: UrlRedirectService,
 ) {
 
@@ -26,7 +26,7 @@ class ShortUrlController(
     @ResponseStatus(HttpStatus.CREATED)
     fun shortUrl(@RequestBody @Valid shortUrlRequest: ShortUrlRequest): ShortUrlResponse {
         urlValidator.validate(shortUrlRequest.originUrl)
-        return urlShortService.shorten(shortUrlRequest)
+        return urlShortenFacade.shortUrlWithLock(shortUrlRequest)
     }
 
     @GetMapping("/redirect/{shortUrl}")

--- a/src/main/kotlin/com/tommy/urlshortener/exception/ServiceUnavailableException.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/exception/ServiceUnavailableException.kt
@@ -1,0 +1,5 @@
+package com.tommy.urlshortener.exception
+
+import org.springframework.http.HttpStatus
+
+class ServiceUnavailableException(pair: Pair<String, String>, vararg args: Any?) : BaseException(HttpStatus.SERVICE_UNAVAILABLE.value(), pair.first, pair.second)

--- a/src/main/kotlin/com/tommy/urlshortener/lock/DistributedLock.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/lock/DistributedLock.kt
@@ -1,0 +1,22 @@
+package com.tommy.urlshortener.lock
+
+import java.util.concurrent.TimeUnit
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DistributedLock(
+
+    val key: String,
+
+    val timeUnit: TimeUnit = TimeUnit.SECONDS,
+
+    /**
+     * 락 대기 시간. 락 획득을 위해 waitTime 만큼 대기한다.
+     */
+    val waitTime: Long = 5L,
+
+    /**
+     * 락 임대 시간. 락을 획득한 후 leaseTime이 지나면 락을 해제한다.
+     */
+    val leaseTime: Long = 3L,
+)

--- a/src/main/kotlin/com/tommy/urlshortener/lock/DistributedLockAop.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/lock/DistributedLockAop.kt
@@ -1,0 +1,69 @@
+package com.tommy.urlshortener.lock
+
+import com.tommy.urlshortener.exception.ServiceUnavailableException
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import org.springframework.stereotype.Component
+import java.lang.reflect.Method
+
+@Aspect
+@Component
+class DistributedLockAop(
+    private val redissonClient: RedissonClient,
+    private val transactionAop: TransactionAop,
+) {
+    private val logger = KotlinLogging.logger { }
+
+    @Around("@annotation(com.tommy.urlshortener.lock.DistributedLock)")
+    fun lock(joinPoint: ProceedingJoinPoint): Any? {
+        val signature = joinPoint.signature as MethodSignature
+        val method = signature.method
+        val distributedLock = method.getAnnotation(DistributedLock::class.java)
+
+        val key = "$REDISSON_LOCK_PREFIX${SpELParser.getDynamicValue(signature.parameterNames, joinPoint.args, distributedLock.key)}"
+
+        val lock = redissonClient.getLock(key)
+
+        return try {
+            val acquired = lock.tryLock(distributedLock.waitTime, distributedLock.leaseTime, distributedLock.timeUnit)
+
+            if (!acquired) {
+                logger.error { "lock acquired failed. key: $key" }
+                return ServiceUnavailableException(LOCK_ACQUIRED_FAILED, key)
+            }
+
+            transactionAop.proceed(joinPoint)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            logger.error { "Current Thread Interrupt. Lock key: $key, message: ${e.message}" }
+            throw e
+        } finally {
+            releaseLock(lock, key, method)
+        }
+    }
+
+    private fun releaseLock(lock: RLock, key: String, method: Method) {
+        try {
+            if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+            }
+        } catch (e: IllegalMonitorStateException) {
+            logger.error { "already unlock. key: ${keyValue("key", key)}, serviceName: ${keyValue("serviceName", method.name)}, message: ${e.message}" }
+        } catch (e: Exception) {
+            logger.error { "failed unlock. key: ${keyValue("key", key)}, serviceName: ${keyValue("serviceName", method.name)}, message: ${e.message}" }
+        }
+    }
+
+    private fun keyValue(key: String, value: Any) = "$key: $value"
+
+    companion object {
+        private const val REDISSON_LOCK_PREFIX = "lock:"
+
+        private val LOCK_ACQUIRED_FAILED = "lock.acquired.failed" to "lock acquired failed. key: {0}"
+    }
+}

--- a/src/main/kotlin/com/tommy/urlshortener/lock/SpELParser.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/lock/SpELParser.kt
@@ -1,0 +1,19 @@
+package com.tommy.urlshortener.lock
+
+import org.springframework.expression.ExpressionParser
+import org.springframework.expression.spel.standard.SpelExpressionParser
+import org.springframework.expression.spel.support.StandardEvaluationContext
+
+object SpELParser {
+
+    fun getDynamicValue(parameterNames: Array<String>, args: Array<Any>, key: String): Any? {
+        val parser: ExpressionParser = SpelExpressionParser()
+        val context = StandardEvaluationContext()
+
+        parameterNames.indices.forEach {
+            context.setVariable(parameterNames[it], args[it])
+        }
+
+        return parser.parseExpression(key).getValue(context, Any::class.java)
+    }
+}

--- a/src/main/kotlin/com/tommy/urlshortener/lock/TransactionAop.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/lock/TransactionAop.kt
@@ -1,0 +1,15 @@
+package com.tommy.urlshortener.lock
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class TransactionAop {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun proceed(joinPoint: ProceedingJoinPoint): Any? {
+        return joinPoint.proceed()
+    }
+}

--- a/src/main/kotlin/com/tommy/urlshortener/repository/ShortenUrlRepository.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/repository/ShortenUrlRepository.kt
@@ -10,6 +10,7 @@ interface ShortenUrlRepository : JpaRepository<ShortenUrl, Long>, ShortenUrlRepo
 
 interface ShortenUrlRepositoryCustom {
     fun findByOriginUrl(originUrl: String): ShortenUrl?
+    fun findByHashedOriginUrl(hashedOriginUrl: String): ShortenUrl?
     fun findByShortUrl(shortUrl: String): ShortenUrl?
 }
 
@@ -22,6 +23,13 @@ class ShortenUrlRepositoryImpl(
         return queryFactory
             .selectFrom(shortenUrl)
             .where(shortenUrl.originUrl.eq(originUrl))
+            .fetchOne()
+    }
+
+    override fun findByHashedOriginUrl(hashedOriginUrl: String): ShortenUrl? {
+        return queryFactory
+            .selectFrom(shortenUrl)
+            .where(shortenUrl.hashedOriginUrl.eq(hashedOriginUrl))
             .fetchOne()
     }
 

--- a/src/main/kotlin/com/tommy/urlshortener/service/UrlShortService.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/UrlShortService.kt
@@ -2,7 +2,6 @@ package com.tommy.urlshortener.service
 
 import com.tommy.urlshortener.cache.ManagedCache
 import com.tommy.urlshortener.domain.ShortenUrl
-import com.tommy.urlshortener.dto.ShortUrlRequest
 import com.tommy.urlshortener.dto.ShortUrlResponse
 import com.tommy.urlshortener.extension.HashAlgorithm
 import com.tommy.urlshortener.extension.toHashedHex
@@ -32,8 +31,8 @@ class UrlShortService(
 
         return cachedShortUrl?.let {
             ShortUrlResponse(it)
-        } ?: run { // findByHashedOriginUrl로 변경 필요
-            val shortenUrl = shortenUrlRepository.findByOriginUrl(hashedOriginUrl) ?: saveShortenUrl(originUrl)
+        } ?: run {
+            val shortenUrl = shortenUrlRepository.findByHashedOriginUrl(hashedOriginUrl) ?: saveShortenUrl(originUrl)
             val shortUrl = shortenUrl.shortUrl
 
             managedCache.set(redisKey, shortUrl, 3L, TimeUnit.DAYS)

--- a/src/main/kotlin/com/tommy/urlshortener/service/UrlShortService.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/UrlShortService.kt
@@ -24,17 +24,15 @@ class UrlShortService(
     private val logger = KotlinLogging.logger { }
 
     @Transactional
-    fun shorten(shortUrlRequest: ShortUrlRequest): ShortUrlResponse {
-        val originUrl = shortUrlRequest.originUrl
+    fun shorten(originUrl: String, hashedOriginUrl: String): ShortUrlResponse {
         logger.debug { "URL Shorten - originUrl: [$originUrl]" }
 
-        val hashedOriginUrl = originUrl.toHashedHex(HashAlgorithm.SHA_256)
         val redisKey = "$REDIS_KEY_PREFIX$hashedOriginUrl"
         val cachedShortUrl = managedCache.get<String>(redisKey)
 
         return cachedShortUrl?.let {
             ShortUrlResponse(it)
-        } ?: run {
+        } ?: run { // findByHashedOriginUrl로 변경 필요
             val shortenUrl = shortenUrlRepository.findByOriginUrl(hashedOriginUrl) ?: saveShortenUrl(originUrl)
             val shortUrl = shortenUrl.shortUrl
 

--- a/src/main/kotlin/com/tommy/urlshortener/service/UrlShortenFacade.kt
+++ b/src/main/kotlin/com/tommy/urlshortener/service/UrlShortenFacade.kt
@@ -1,0 +1,27 @@
+package com.tommy.urlshortener.service
+
+import com.tommy.urlshortener.dto.ShortUrlRequest
+import com.tommy.urlshortener.dto.ShortUrlResponse
+import com.tommy.urlshortener.extension.HashAlgorithm
+import com.tommy.urlshortener.extension.toHashedHex
+import com.tommy.urlshortener.lock.DistributedLock
+import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
+
+@Service
+class UrlShortenFacade(
+    private val urlShortService: UrlShortService,
+) {
+
+    fun shortUrlWithLock(shortUrlRequest: ShortUrlRequest): ShortUrlResponse {
+        val originUrl = shortUrlRequest.originUrl
+        val hashedOriginUrl = originUrl.toHashedHex(HashAlgorithm.SHA_256)
+
+        return shortUrlWithLock(originUrl, hashedOriginUrl)
+    }
+
+    @DistributedLock(key = "#hashedOriginUrl", waitTime = 4L, leaseTime = 5L, timeUnit = TimeUnit.SECONDS)
+    private fun shortUrlWithLock(originUrl: String, hashedOriginUrl: String): ShortUrlResponse {
+        return urlShortService.shorten(originUrl, hashedOriginUrl)
+    }
+}

--- a/src/test/kotlin/com/tommy/urlshortener/config/TestMockConfig.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/config/TestMockConfig.kt
@@ -1,11 +1,12 @@
 package com.tommy.urlshortener.config
 
 import com.ninjasquad.springmockk.MockkBean
+import com.tommy.urlshortener.lock.DistributedLockAop
+import io.mockk.impl.annotations.InjectMockKs
+import org.redisson.api.RedissonClient
 import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.context.annotation.Bean
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory
 import org.springframework.data.redis.connection.RedisConnectionFactory
-import org.springframework.data.redis.core.RedisTemplate
 
 @TestConfiguration
 class TestMockConfig {
@@ -14,12 +15,13 @@ class TestMockConfig {
     class RedisMockConfig(
         @MockkBean private val redisConnectionFactory: RedisConnectionFactory,
         @MockkBean private val reactiveRedisConnectionFactory: ReactiveRedisConnectionFactory,
+    )
+
+    @TestConfiguration
+    class LockMockConfig(
+        @MockkBean private val redissonClient: RedissonClient
     ) {
-        @Bean
-        fun redisTemplate(): RedisTemplate<String, Any> {
-            val redisTemplate = RedisTemplate<String, Any>()
-            redisTemplate.connectionFactory = redisConnectionFactory
-            return redisTemplate
-        }
+        @InjectMockKs
+        private lateinit var distributedLockAop: DistributedLockAop
     }
 }

--- a/src/test/kotlin/com/tommy/urlshortener/controller/ShortUrlControllerTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/controller/ShortUrlControllerTest.kt
@@ -7,7 +7,7 @@ import com.tommy.urlshortener.dto.ShortUrlRequest
 import com.tommy.urlshortener.dto.ShortUrlResponse
 import com.tommy.urlshortener.exception.BadRequestException
 import com.tommy.urlshortener.service.UrlRedirectService
-import com.tommy.urlshortener.service.UrlShortService
+import com.tommy.urlshortener.service.UrlShortenFacade
 import com.tommy.urlshortener.service.UrlValidator
 import io.mockk.every
 import io.mockk.verify
@@ -32,7 +32,7 @@ class ShortUrlControllerTest @Autowired constructor(
     private val mockMvc: MockMvc,
     private val objectMapper: ObjectMapper,
     @MockkBean private val urlValidator: UrlValidator,
-    @MockkBean private val urlShortService: UrlShortService,
+    @MockkBean private val urlShortenFacade: UrlShortenFacade,
     @MockkBean private val urlRedirectService: UrlRedirectService,
 ) {
 
@@ -45,7 +45,7 @@ class ShortUrlControllerTest @Autowired constructor(
         val shortUrlResponse = ShortUrlResponse("EysI9lHD")
 
         every { urlValidator.validate(shortUrlRequest.originUrl) } returns true
-        every { urlShortService.shorten(shortUrlRequest) } returns shortUrlResponse
+        every { urlShortenFacade.shortUrlWithLock(shortUrlRequest) } returns shortUrlResponse
 
         // Act & Assert
         mockMvc.perform(
@@ -58,7 +58,7 @@ class ShortUrlControllerTest @Autowired constructor(
             .andExpect(jsonPath("$.shortUrl").value(shortUrlResponse.shortUrl))
 
         verify {
-            urlShortService.shorten(shortUrlRequest)
+            urlShortenFacade.shortUrlWithLock(shortUrlRequest)
         }
     }
 
@@ -86,7 +86,7 @@ class ShortUrlControllerTest @Autowired constructor(
             .andExpect(jsonPath("$.errorFields").isEmpty)
 
         verify { urlValidator.validate(originUrl) }
-        verify(exactly = 0) { urlShortService.shorten(shortUrlRequest) }
+        verify(exactly = 0) { urlShortenFacade.shortUrlWithLock(shortUrlRequest) }
     }
 
     @Test

--- a/src/test/kotlin/com/tommy/urlshortener/repository/ShortenUrlRepositoryTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/repository/ShortenUrlRepositoryTest.kt
@@ -37,6 +37,24 @@ class ShortenUrlRepositoryTest @Autowired constructor(
     }
 
     @Test
+    @DisplayName("hashedOriginUrl이 주어질 경우 ShortenUrl Entity를 조회한다.")
+    fun `find by hashed origin url`() {
+        // Arrange
+        val originUrl = "https://github.com/LimHanGyeol/url-shortener/blob/master/src/main/kotlin/com/tommy/urlshortener/UrlShortenerApplication.kt"
+        val hashedOriginUrl = originUrl.toHashedHex(HashAlgorithm.SHA_256)
+
+        val shortenUrl = ShortenUrl(shortenKey = 1696691294L, originUrl = originUrl, hashedOriginUrl = hashedOriginUrl, shortUrl = "EysI9lHD")
+
+        sut.save(shortenUrl)
+
+        // Act
+        val actual = sut.findByHashedOriginUrl(hashedOriginUrl)
+
+        // Assert
+        assertThat(actual?.hashedOriginUrl).isEqualTo(shortenUrl.hashedOriginUrl)
+    }
+
+    @Test
     @DisplayName("shortUrl이 주어질 경우 ShortenUrl Entity를 조회한다.")
     fun `find by short url`() {
         // Arrange

--- a/src/test/kotlin/com/tommy/urlshortener/service/UrlShortServiceTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/service/UrlShortServiceTest.kt
@@ -2,7 +2,6 @@ package com.tommy.urlshortener.service
 
 import com.tommy.urlshortener.cache.ManagedCache
 import com.tommy.urlshortener.domain.ShortenUrl
-import com.tommy.urlshortener.dto.ShortUrlRequest
 import com.tommy.urlshortener.extension.HashAlgorithm
 import com.tommy.urlshortener.extension.toHashedHex
 import com.tommy.urlshortener.repository.ShortenUrlRepository
@@ -11,6 +10,7 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.justRun
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -40,7 +40,7 @@ class UrlShortServiceTest(
         val shortenUrl = ShortenUrl(shortenKey = shortenKey, originUrl = originUrl, hashedOriginUrl = hashedOriginUrl, shortUrl = generatedShortUrl)
 
         every { managedCache.get<String>(redisKey) } returns null
-        every { shortenUrlRepository.findByOriginUrl(hashedOriginUrl) } returns null
+        every { shortenUrlRepository.findByHashedOriginUrl(hashedOriginUrl) } returns null
         every { shortenKeyGenerator.generate(any()) } returns shortenKey
         every { shortUrlGenerator.generate(shortenKey) } returns generatedShortUrl
         every { shortenUrlRepository.save(any()) } returns shortenUrl
@@ -51,6 +51,11 @@ class UrlShortServiceTest(
 
         // Assert
         assertThat(actual.shortUrl).isEqualTo(generatedShortUrl)
+
+        verify {
+            managedCache.get<String>(redisKey)
+            shortenUrlRepository.findByHashedOriginUrl(hashedOriginUrl)
+        }
     }
 
     companion object {

--- a/src/test/kotlin/com/tommy/urlshortener/service/UrlShortServiceTest.kt
+++ b/src/test/kotlin/com/tommy/urlshortener/service/UrlShortServiceTest.kt
@@ -32,8 +32,6 @@ class UrlShortServiceTest(
     fun `shorten origin url`() {
         // Arrange
         val originUrl = "https://github.com/LimHanGyeol/url-shortener/blob/master/src/main/kotlin/com/tommy/urlshortener/UrlShortenerApplication.kt"
-        val shortUrlRequest = ShortUrlRequest(originUrl)
-
         val hashedOriginUrl = originUrl.toHashedHex(HashAlgorithm.SHA_256)
         val redisKey = "$REDIS_KEY_PREFIX$hashedOriginUrl"
 
@@ -49,7 +47,7 @@ class UrlShortServiceTest(
         justRun { managedCache.set(redisKey, shortenUrl.shortUrl, 3L, TimeUnit.DAYS) }
 
         // Act
-        val actual = sut.shorten(shortUrlRequest)
+        val actual = sut.shorten(originUrl, hashedOriginUrl)
 
         // Assert
         assertThat(actual.shortUrl).isEqualTo(generatedShortUrl)


### PR DESCRIPTION
요청 연산이 많을 경우 같은 OriginUrl의 단축을 동시에 요청할 수 있는 경우가 있다.
이를 처리하기 위해 Redis Distributed Lock을 도입한다.

대용량 트래픽을 가정하고 진행하기 때문에 DB 부하가 생길 수 있어 DB Lock은 선택하지 않는다.
스케일 아웃을 고려한 멀티 스레드 환경이므로 JVM synchrozied은 선택하지 않는다.
이미 Cache 용도로 Redis를 선택한 상황. Global한 분산락 구현을 위해 Redis를 선택한다.
Lettuce의 경우 스핀락으로 동작하여 Redis에 부하를 주고, 타임아웃 등을 구현해야하기 때문에 선택하지 않는다.
Pub/Sub 기반의 Lock인 Redisson을 선택한다.


#### Redis Distributed Lock 기능 구현
- Redisson을 이용하여 DistributedLock을 구현한다.
- Annotation 기반의 AOP 구현
- RedisConfig의 Client 설정 코드에서 운영 시 Redis Cluster를 이용할 상황을 고려해야한다.
- SpELParser의 경우 표현식과 Value를 매번 생성하기 때문에 처리량이 높아질 수 있다. 개선을 고려해야한다.
- Lock을 획득하지 못했을 경우 ServiceUnavailableException 발생
- 트랜잭션이 commit 된 후 unlock이 진행되어야한다. 그렇지 않으면 정합성 불일치 문제가 발생한다.
- TransactionAop로 잠금과 트랜잭션 관리를 함께 수행한다.
  - 잠금을 획득 한 후 transactionAop.proceed(joinPoint)를 호출하여 비즈니스 로직을 새로운 트랜잭션(Propagation.REQUIRES_NEW)에서 실행되도록 한다.
  - 비즈니스 로직이 완료되면 트랜잭션에 의해 커밋 혹은 롤백이 된다.
  - 트랜잭션 종료 후 finally에서 unlock을 한다.
  - DistributedLock 최대한 최상단에서 사용하도록 한다. lock을 먼저 점유한 후 트랜잭션을 시작해야한다.
  - 트랜잭션 먼저 시작 후 lock을 점유할 경우 동시 요청이 많이 들어오면 DBCP를 계속 점유하고 있어 처리량이 떨어지게 된다.
- lock의 경우 대기 시간을 고려하여 로직이 대기시간보다 길어지지 않게 염두하여 사용한다.


#### UrlShortenFacade 적용
- ShortUrlController.shortUrl 호출 Bean을 UrlShortenFacade로 변경한다.
- 테스트코드 전파 사항 변경

#### TestMockConfig 개선
- Solitray Test를 위해 외부 의존성 Mock 개선
- redisTempalte의 경우 production code는 RedisTemplate<String, String>을 사용하고 있고, data redis의 기본 구현체를 이용하고 있다. 필요가 없으므로 제거한다.
- redissonClient와 distributedAop의 경우 Solitray Test 기준 Redis Connection 맺을 필요가 없다. 정상 동작을 위해 해당 MockBean을 생성한다.
- redisson의 경우 통합 테스트를 위해 TestContainer를 구축하도록 한다.

#### ShortenUrlRepository.findByHashedOriginUrl 추가
- findByHashedOriginUrl 메서드가 누락된 것을 확인. 이를 추가한다.
- URL 단축 시 hashedOriginUrl로 동작하도록 한다.

work items: https://github.com/LimHanGyeol/url-shortener/issues/30