### PR TITLE
테스트 커버리지 측정을 위한 Jacoco 설정

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: Checks
+name: Checks and Coverage Report
 on:
   pull_request:
   workflow_dispatch:
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -28,3 +28,19 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: ${{ env.GRADLE_BUILD_CMD }}
+
+      - name: Upload Jacoco Report
+        uses: actions/upload-artifact@v2
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/jacocoTestReport.xml
+
+      - name: Test Coverage Report
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          title: Test Coverage Report
+          paths: ${{ github.workspace }}/**/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 0
+          min-coverage-changed-files: 0


### PR DESCRIPTION
- jacoco 설정
- jacocoTestReport와 jacocoTestCoverageVerification Task에서 Class를 둘 다 제외할 수 있다.
- 차이는 아래와 같다.
  - jacocoTestReport에서 제외할 경우: 테스트 리포트에서 완전 제외됨
  - jacocoTestCoverageVerification에서 제외할 경우: 리포트에는 포함되지만 최종 커버리지 비율 계산에서는 무시됨
- Check Pipeline에 Test Coverage를 Comment로 추가하도록 한다.
- Test Coverage Comment 링크: https://github.com/Madrapps/jacoco-report

work items: #48